### PR TITLE
Fix lint setup, harden theme/link handling, and drop trailing commas

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,7 +2,7 @@
 	"useTabs": true,
 	"tabWidth": 2,
 	"singleQuote": true,
-	"trailingComma": "all",
+	"trailingComma": "none",
 	"quoteProps": "consistent",
 	"semi": true,
 	"printWidth": 100,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,19 +14,19 @@ export default tseslint.config(
 		languageOptions: {
 			globals: {
 				...globals.browser,
-				...globals.node,
-			},
-		},
+				...globals.node
+			}
+		}
 	},
 	{
 		files: ['**/*.svelte'],
 		languageOptions: {
 			parserOptions: {
-				parser: tseslint.parser,
-			},
-		},
+				parser: tseslint.parser
+			}
+		}
 	},
 	{
-		ignores: ['build/', '.svelte-kit/', 'dist/'],
-	},
+		ignores: ['build/', '.svelte-kit/', 'dist/']
+	}
 );

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"zod": "^4.3.6"
 	},
 	"devDependencies": {
+		"@eslint/js": "10.0.1",
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.53.0",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
@@ -35,7 +36,7 @@
 		"jsdom": "^28.1.0",
 		"prettier": "^3.8.1",
 		"prettier-plugin-svelte": "^3.5.0",
-		"svelte": "^5.53.1",
+		"svelte": "^5.53.2",
 		"svelte-check": "^4.4.3",
 		"svgo": "^4.0.0",
 		"typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,15 +18,18 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@eslint/js':
+        specifier: 10.0.1
+        version: 10.0.1(eslint@10.0.1)
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.53.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.1)(vite@7.3.1(@types/node@25.0.3)))(svelte@5.53.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3)))
+        version: 3.0.10(@sveltejs/kit@2.53.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@25.0.3)))(svelte@5.53.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3)))
       '@sveltejs/kit':
         specifier: ^2.53.0
-        version: 2.53.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.1)(vite@7.3.1(@types/node@25.0.3)))(svelte@5.53.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3))
+        version: 2.53.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@25.0.3)))(svelte@5.53.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.4
-        version: 6.2.4(svelte@5.53.1)(vite@7.3.1(@types/node@25.0.3))
+        version: 6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@25.0.3))
       '@types/jsdom':
         specifier: ^27.0.0
         version: 27.0.0
@@ -44,7 +47,7 @@ importers:
         version: 10.1.8(eslint@10.0.1)
       eslint-plugin-svelte:
         specifier: ^3.15.0
-        version: 3.15.0(eslint@10.0.1)(svelte@5.53.1)
+        version: 3.15.0(eslint@10.0.1)(svelte@5.53.2)
       glob:
         specifier: ^13.0.6
         version: 13.0.6
@@ -59,13 +62,13 @@ importers:
         version: 3.8.1
       prettier-plugin-svelte:
         specifier: ^3.5.0
-        version: 3.5.0(prettier@3.8.1)(svelte@5.53.1)
+        version: 3.5.0(prettier@3.8.1)(svelte@5.53.2)
       svelte:
-        specifier: ^5.53.1
-        version: 5.53.1
+        specifier: ^5.53.2
+        version: 5.53.2
       svelte-check:
         specifier: ^4.4.3
-        version: 4.4.3(picomatch@4.0.3)(svelte@5.53.1)(typescript@5.9.3)
+        version: 4.4.3(picomatch@4.0.3)(svelte@5.53.2)(typescript@5.9.3)
       svgo:
         specifier: ^4.0.0
         version: 4.0.0
@@ -311,6 +314,15 @@ packages:
   '@eslint/core@1.1.0':
     resolution: {integrity: sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
   '@eslint/object-schema@3.0.2':
     resolution: {integrity: sha512-HOy56KJt48Bx8KmJ+XGQNSUMT/6dZee/M54XyUyuvTvPXJmsERRvBchsUVx1UMe1WwIH49XLAczNC7V2INsuUw==}
@@ -1220,8 +1232,8 @@ packages:
       svelte:
         optional: true
 
-  svelte@5.53.1:
-    resolution: {integrity: sha512-WzxFHZhhD23Qzu7JCYdvm1rxvRSzdt9HtHO8TScMBX51bLRFTcJmATVqjqXG+6Ln6hrViGCo9DzwOhAasxwC/w==}
+  svelte@5.53.2:
+    resolution: {integrity: sha512-yGONuIrcl/BMmqbm6/52Q/NYzfkta7uVlos5NSzGTfNJTTFtPPzra6rAQoQIwAqupeM3s9uuTf5PvioeiCdg9g==}
     engines: {node: '>=18'}
 
   svgo@4.0.0:
@@ -1541,6 +1553,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
+  '@eslint/js@10.0.1(eslint@10.0.1)':
+    optionalDependencies:
+      eslint: 10.0.1
+
   '@eslint/object-schema@3.0.2': {}
 
   '@eslint/plugin-kit@0.6.0':
@@ -1654,15 +1670,15 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.53.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.1)(vite@7.3.1(@types/node@25.0.3)))(svelte@5.53.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.53.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@25.0.3)))(svelte@5.53.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3)))':
     dependencies:
-      '@sveltejs/kit': 2.53.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.1)(vite@7.3.1(@types/node@25.0.3)))(svelte@5.53.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3))
+      '@sveltejs/kit': 2.53.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@25.0.3)))(svelte@5.53.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3))
 
-  '@sveltejs/kit@2.53.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.1)(vite@7.3.1(@types/node@25.0.3)))(svelte@5.53.1)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3))':
+  '@sveltejs/kit@2.53.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@25.0.3)))(svelte@5.53.2)(typescript@5.9.3)(vite@7.3.1(@types/node@25.0.3))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.53.1)(vite@7.3.1(@types/node@25.0.3))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@25.0.3))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -1673,27 +1689,27 @@ snapshots:
       mrmime: 2.0.1
       set-cookie-parser: 3.0.1
       sirv: 3.0.2
-      svelte: 5.53.1
+      svelte: 5.53.2
       vite: 7.3.1(@types/node@25.0.3)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.1)(vite@7.3.1(@types/node@25.0.3)))(svelte@5.53.1)(vite@7.3.1(@types/node@25.0.3))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@25.0.3)))(svelte@5.53.2)(vite@7.3.1(@types/node@25.0.3))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.53.1)(vite@7.3.1(@types/node@25.0.3))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@25.0.3))
       debug: 4.4.3
-      svelte: 5.53.1
+      svelte: 5.53.2
       vite: 7.3.1(@types/node@25.0.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.1)(vite@7.3.1(@types/node@25.0.3))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@25.0.3))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.1)(vite@7.3.1(@types/node@25.0.3)))(svelte@5.53.1)(vite@7.3.1(@types/node@25.0.3))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.2)(vite@7.3.1(@types/node@25.0.3)))(svelte@5.53.2)(vite@7.3.1(@types/node@25.0.3))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
-      svelte: 5.53.1
+      svelte: 5.53.2
       vite: 7.3.1(@types/node@25.0.3)
       vitefu: 1.1.1(vite@7.3.1(@types/node@25.0.3))
     transitivePeerDependencies:
@@ -1992,7 +2008,7 @@ snapshots:
     dependencies:
       eslint: 10.0.1
 
-  eslint-plugin-svelte@3.15.0(eslint@10.0.1)(svelte@5.53.1):
+  eslint-plugin-svelte@3.15.0(eslint@10.0.1)(svelte@5.53.2):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@10.0.1)
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -2004,9 +2020,9 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.6)
       postcss-safe-parser: 7.0.1(postcss@8.5.6)
       semver: 7.7.3
-      svelte-eslint-parser: 1.4.1(svelte@5.53.1)
+      svelte-eslint-parser: 1.4.1(svelte@5.53.2)
     optionalDependencies:
-      svelte: 5.53.1
+      svelte: 5.53.2
     transitivePeerDependencies:
       - ts-node
 
@@ -2339,10 +2355,10 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.5.0(prettier@3.8.1)(svelte@5.53.1):
+  prettier-plugin-svelte@3.5.0(prettier@3.8.1)(svelte@5.53.2):
     dependencies:
       prettier: 3.8.1
-      svelte: 5.53.1
+      svelte: 5.53.2
 
   prettier@3.8.1: {}
 
@@ -2421,19 +2437,19 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  svelte-check@4.4.3(picomatch@4.0.3)(svelte@5.53.1)(typescript@5.9.3):
+  svelte-check@4.4.3(picomatch@4.0.3)(svelte@5.53.2)(typescript@5.9.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       chokidar: 4.0.3
       fdir: 6.5.0(picomatch@4.0.3)
       picocolors: 1.1.1
       sade: 1.8.1
-      svelte: 5.53.1
+      svelte: 5.53.2
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
 
-  svelte-eslint-parser@1.4.1(svelte@5.53.1):
+  svelte-eslint-parser@1.4.1(svelte@5.53.2):
     dependencies:
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -2442,9 +2458,9 @@ snapshots:
       postcss-scss: 4.0.9(postcss@8.5.6)
       postcss-selector-parser: 7.1.1
     optionalDependencies:
-      svelte: 5.53.1
+      svelte: 5.53.2
 
-  svelte@5.53.1:
+  svelte@5.53.2:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       '@jridgewell/sourcemap-codec': 1.5.5

--- a/scripts/process-svgs.ts
+++ b/scripts/process-svgs.ts
@@ -58,7 +58,7 @@ const colorMatchers: ColorMatch[] = [
 
 	// Theme colors
 	{ attrs: { fill: '#46A758' }, className: 'fill-theme' },
-	{ attrs: { fill: '#2A7E3B' }, className: 'fill-theme-text' },
+	{ attrs: { fill: '#2A7E3B' }, className: 'fill-theme-text' }
 ];
 
 // Helper function to check if an element matches a color matcher
@@ -112,10 +112,10 @@ const svgoConfig: Config = {
 			params: {
 				overrides: {
 					cleanupNumericValues: {
-						floatPrecision: 3,
+						floatPrecision: 3
 					},
 					convertTransform: {
-						transformPrecision: 5,
+						transformPrecision: 5
 					},
 					cleanupIds: false,
 					removeViewBox: false,
@@ -124,18 +124,18 @@ const svgoConfig: Config = {
 						shortname: false,
 						rgb2hex: true,
 						names2hex: true,
-						currentColor: false,
-					},
-				},
-			},
+						currentColor: false
+					}
+				}
+			}
 		},
 		{
 			name: 'addClassesToSVGElement',
 			params: {
-				classNames: ['portfolio-widget'],
-			},
-		},
-	],
+				classNames: ['portfolio-widget']
+			}
+		}
+	]
 };
 
 // Create output directory if it doesn't exist
@@ -156,7 +156,7 @@ const globPromise = (pattern: string): Promise<string[]> => {
 
 // Main processing function
 async function processSvgFiles(
-	options: { optimizeSvgs?: boolean; processColors?: boolean } = {},
+	options: { optimizeSvgs?: boolean; processColors?: boolean } = {}
 ): Promise<void> {
 	// Set default options
 	const { optimizeSvgs = true, processColors: shouldProcessColors = true } = options;
@@ -176,7 +176,7 @@ async function processSvgFiles(
 				if (optimizeSvgs) {
 					const result = optimize(svg, {
 						path: file,
-						...svgoConfig,
+						...svgoConfig
 					});
 					processed = result.data;
 				}
@@ -192,7 +192,7 @@ async function processSvgFiles(
 			} catch (error) {
 				console.error(
 					`Error processing ${filename}:`,
-					error instanceof Error ? error.message : error,
+					error instanceof Error ? error.message : error
 				);
 			}
 		}
@@ -205,5 +205,5 @@ async function processSvgFiles(
 // Run the script
 processSvgFiles({
 	optimizeSvgs: true,
-	processColors: true,
+	processColors: true
 });

--- a/src/components/BackgroundGrid.svelte
+++ b/src/components/BackgroundGrid.svelte
@@ -3,17 +3,17 @@
 		widthCells,
 		heightCells,
 		subdivisions = 4,
-		class: className,
+		class: className
 	}: { widthCells: number; heightCells: number; subdivisions?: number; class?: string } = $props();
 
 	// Create arrays for the gridlines
 	const majorVerticals = $derived(Array.from({ length: widthCells + 1 }, (_, i) => i));
 	const majorHorizontals = $derived(Array.from({ length: heightCells + 1 }, (_, i) => i));
 	const minorVerticals = $derived(
-		Array.from({ length: widthCells * subdivisions + 1 }, (_, i) => i / subdivisions),
+		Array.from({ length: widthCells * subdivisions + 1 }, (_, i) => i / subdivisions)
 	);
 	const minorHorizontals = $derived(
-		Array.from({ length: heightCells * subdivisions + 1 }, (_, i) => i / subdivisions),
+		Array.from({ length: heightCells * subdivisions + 1 }, (_, i) => i / subdivisions)
 	);
 
 	const verticalPath = (x: number) => `M ${x} 0 L ${x} ${heightCells}`;

--- a/src/components/ProfileContent.svelte
+++ b/src/components/ProfileContent.svelte
@@ -31,7 +31,7 @@
 					{@const IconComponent = link.icon}
 					<li>
 						<!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- external link -->
-						<a class="link" href={link.href} target="_blank">
+						<a class="link" href={link.href} target="_blank" rel="noopener noreferrer">
 							<IconComponent />
 							<span class="label">{link.label}</span>
 						</a>

--- a/src/components/ProfileContent.svelte
+++ b/src/components/ProfileContent.svelte
@@ -9,11 +9,11 @@
 		{
 			href: 'https://barnsworthburning.net/creators/rec97tRUYZBhAs6rZ',
 			label: 'Commonplace',
-			icon: Archive,
+			icon: Archive
 		},
 		{ href: 'https://github.com/Aias', label: 'Github', icon: Github },
 		{ href: 'https://www.linkedin.com/in/nick-trombley/', label: 'LinkedIn', icon: LinkedIn },
-		{ href: 'https://glass.photo/barnsworthburning', label: 'Photography', icon: Camera },
+		{ href: 'https://glass.photo/barnsworthburning', label: 'Photography', icon: Camera }
 	];
 </script>
 

--- a/src/components/SEO.svelte
+++ b/src/components/SEO.svelte
@@ -26,7 +26,7 @@
 		robots = 'index, follow',
 		themeColor = '#1f0066',
 		keywords = 'Nick Trombley, portfolio, software design, design-build, barnsworthburning',
-		author = 'Nick Trombley',
+		author = 'Nick Trombley'
 	}: SEOProps = $props();
 </script>
 

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -20,7 +20,7 @@ export const load = async ({ fetch, cookies }) => {
 	const csvData = parse(fileContent, {
 		columns: true,
 		skip_empty_lines: true,
-		bom: true, // This removes the BOM character from column headers
+		bom: true // This removes the BOM character from column headers
 	});
 
 	// Validate and transform the data with Zod schema
@@ -28,6 +28,6 @@ export const load = async ({ fetch, cookies }) => {
 
 	return {
 		widgets,
-		theme,
+		theme
 	};
 };

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -6,7 +6,8 @@ export const prerender = true;
 export const ssr = true;
 
 export const load = async ({ fetch, cookies }) => {
-	const theme = ThemeSchema.parse(cookies.get('theme'));
+	const themeResult = ThemeSchema.safeParse(cookies.get('theme'));
+	const theme = themeResult.success ? themeResult.data : undefined;
 	// Fetch the CSV file from the static data directory
 	const response = await fetch('/data/portfolio-widgets.csv');
 	if (!response.ok) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,17 +12,17 @@
 	let loaded = $state(false);
 
 	const contentLargeWidthRems = $derived(
-		Math.max(...widgets.map((w) => (w.xLgCells + w.widthCells) * REMS_PER_CELL)),
+		Math.max(...widgets.map((w) => (w.xLgCells + w.widthCells) * REMS_PER_CELL))
 	);
 	const contentLargeHeightRems = $derived(
-		Math.max(...widgets.map((w) => (w.yLgCells + w.heightCells) * REMS_PER_CELL)),
+		Math.max(...widgets.map((w) => (w.yLgCells + w.heightCells) * REMS_PER_CELL))
 	);
 
 	const contentSmallWidthRems = $derived(
-		Math.max(...widgets.map((w) => (w.xSmCells + w.widthCells) * REMS_PER_CELL)),
+		Math.max(...widgets.map((w) => (w.xSmCells + w.widthCells) * REMS_PER_CELL))
 	);
 	const contentSmallHeightRems = $derived(
-		Math.max(...widgets.map((w) => (w.ySmCells + w.heightCells) * REMS_PER_CELL)),
+		Math.max(...widgets.map((w) => (w.ySmCells + w.heightCells) * REMS_PER_CELL))
 	);
 
 	let profileNode: HTMLElement;
@@ -37,14 +37,14 @@
 		width: 32 * 32,
 		height: 11 * 32,
 		widthCells: 32,
-		heightCells: 11,
+		heightCells: 11
 	};
 
 	onMount(async () => {
 		profileNode.scrollIntoView({
 			behavior: 'instant',
 			block: 'center',
-			inline: 'center',
+			inline: 'center'
 		});
 		loaded = true;
 	});

--- a/src/types/portfolio.ts
+++ b/src/types/portfolio.ts
@@ -14,7 +14,7 @@ export const WidgetsSchema = z.object({
 	xSmCells: z.coerce.number(),
 	ySmCells: z.coerce.number(),
 	widthCells: z.coerce.number(),
-	heightCells: z.coerce.number(),
+	heightCells: z.coerce.number()
 });
 // Create a type from the Zod schema
 export type Widget = z.infer<typeof WidgetsSchema>;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -10,12 +10,12 @@ const config = {
 			$components: 'src/components',
 			$helpers: 'src/helpers',
 			$styles: 'src/styles',
-			$types: 'src/types',
-		},
+			$types: 'src/types'
+		}
 	},
 	compilerOptions: {
-		runes: true,
-	},
+		runes: true
+	}
 };
 
 export default config;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,5 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()],
+	plugins: [sveltekit()]
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,6 @@
 	"name": "nicktrombley-design",
 	"compatibility_date": "2026-02-21",
 	"assets": {
-		"directory": "./build"
-	}
+		"directory": "./build",
+	},
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,6 +2,6 @@
 	"name": "nicktrombley-design",
 	"compatibility_date": "2026-02-21",
 	"assets": {
-		"directory": "./build",
-	},
+		"directory": "./build"
+	}
 }


### PR DESCRIPTION
Linting fails because the ESLint flat config imports a package that was not installed, and formatting policy/runtime safety gaps remained in the workspace diff.

- Adds exact `@eslint/js` in devDependencies and refreshes `pnpm-lock.yaml` (including the Svelte patch-level lockfile bump)
- Replaces throwing theme cookie parsing with `safeParse` and an `undefined` fallback in layout load
- Adds `rel=\"noopener noreferrer\"` for profile external links opened with `target=\"_blank\"`
- Changes Prettier from `trailingComma: "all"` to `"none"` and reapplies formatting across touched files